### PR TITLE
SSH Client, VOLUMES versatility, cleaner logs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,8 @@ services:
     volumes:
       - "./netdisco/nd-site-local:/home/netdisco/nd-site-local"
       - "./netdisco/config:/home/netdisco/environments"
-      - "./netdisco/logs:/home/netdisco/logs"
+# logs are symlinked to stdout
+#      - "./netdisco/logs:/home/netdisco/logs"
     environment:
       NETDISCO_DOMAIN:  discover
       NETDISCO_DB_HOST: netdisco-postgresql

--- a/netdisco-base/Dockerfile
+++ b/netdisco-base/Dockerfile
@@ -66,7 +66,10 @@ RUN groupadd -r netdisco -g 901 && \
 
 USER netdisco:netdisco
 RUN for tgt in bin environments nd-site-local logs; \
-      do mkdir /home/netdisco/$tgt; done
+      do mkdir /home/netdisco/$tgt; done && \
+      ln -s /dev/stdout /home/netdisco/logs/netdisco-backend.log && \
+      ln -s /dev/stdout /home/netdisco/logs/netdisco-web.log
+
 
 COPY --chown=netdisco:netdisco --from=netdisco-builder-image \
   /home/netdisco-build /home/netdisco/
@@ -84,6 +87,7 @@ WORKDIR /home/netdisco
 ENV PATH "/home/netdisco/bin:$PATH"
 ENV SHELL /bin/ash
 
-VOLUME ["/home/netdisco/environments", "/home/netdisco/nd-site-local", "/home/netdisco/logs"]
+## volumes can be optional, and controlled by docker-compose file
+# VOLUME ["/home/netdisco/environments", "/home/netdisco/nd-site-local", "/home/netdisco/logs"]
 
 CMD ["ash"]

--- a/netdisco-base/Dockerfile
+++ b/netdisco-base/Dockerfile
@@ -19,6 +19,7 @@ RUN apk add --no-cache \
       perl-io-socket-ssl \
       perl-ldap \
       postgresql-client \
+      openssh-client \
       wget && \
     apk fix --no-cache perl perl-dev
 


### PR DESCRIPTION
first 2 are straightforward, but third refers to not requiring a volume for the log files (though this is still an option of course if you want to overwrite the symlink)

Resolves #12  and #23 