### PR TITLE
Working around a build issue with Authen::TacacsPlus

### DIFF
--- a/netdisco-base/Dockerfile
+++ b/netdisco-base/Dockerfile
@@ -26,6 +26,8 @@ WORKDIR /tmp
 RUN curl -sL -o /tmp/cpanm https://cpanmin.us/ && \
   chmod +x /tmp/cpanm
 
+COPY file.h /usr/include/sys/file.h
+
 WORKDIR /home/netdisco
 RUN PERL5LIB='.' /tmp/cpanm --quiet --notest --local-lib ./perl5 \
   "https://github.com/netdisco/netdisco.git@${COMMITTISH}" && \

--- a/netdisco-base/file.h
+++ b/netdisco-base/file.h
@@ -1,0 +1,25 @@
+#ifndef _SYS_FILE_H
+#define _SYS_FILE_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef _FCNTL_H
+# include <fcntl.h>
+#endif
+
+#define LOCK_SH	1
+#define LOCK_EX	2
+#define LOCK_NB	4
+#define LOCK_UN	8
+
+#define L_SET 0
+#define L_INCR 1
+#define L_XTND 2
+
+int flock(int, int);
+
+#ifdef __cplusplus
+}
+#endif
+#endif


### PR DESCRIPTION
This fixes #27 by patching <sys/file.h> to include <fcntl.h>. This workaround can be removed once Authen::TacacsPlus is fixed ([ticket](https://rt.cpan.org/Ticket/Display.html?id=131709))