### PR TITLE
Upgrade Postgres Major Version

### DIFF
--- a/netdisco-postgresql/Dockerfile
+++ b/netdisco-postgresql/Dockerfile
@@ -1,5 +1,5 @@
 # vim: ft=Dockerfile
-FROM docker.io/postgres:13.4-alpine
+FROM docker.io/postgres:17.2-alpine
 
 ARG BUILD_DATE
 ARG COMMITTISH=HEAD
@@ -18,6 +18,7 @@ LABEL org.label-schema.docker.schema-version="1.0" \
       org.netdisco.version=${COMMITTISH}
 
 RUN apk add --no-cache \
+  su-exec \
   curl \
   tzdata \
   tar

--- a/netdisco-postgresql/Dockerfile
+++ b/netdisco-postgresql/Dockerfile
@@ -25,6 +25,7 @@ RUN apk add --no-cache \
 
 COPY netdisco-initdb.sh /docker-entrypoint-initdb.d/
 COPY netdisco-db-entrypoint.sh netdisco-updatedb.sh /usr/local/bin/
+COPY README_UPGRADE.md /
 RUN chmod +x /usr/local/bin/netdisco-*
 
 WORKDIR /var/lib/postgresql/netdisco-sql

--- a/netdisco-postgresql/README_UPGRADE.md
+++ b/netdisco-postgresql/README_UPGRADE.md
@@ -3,10 +3,11 @@ Beginning from version 2.09000 netdisco-docker includes Postgres 17,
 while the existing database is an older major version.
 
 It's possible to upgrade the old database in-place using pgautoupgrade, 
-executed in the directory where docker-compose.yml is located:
+executed in the directory where docker-compose.yml is located. Make 
+sure all other netdisco containers are stopped.
 
 ```
-docker run --name pgauto -it \
+docker run --rm -it \
   --mount type=bind,source=$PWD/netdisco/pgdata,target=/var/lib/postgresql/data \
   -e PGAUTO_ONESHOT=yes \
   pgautoupgrade/pgautoupgrade:17-alpine

--- a/netdisco-postgresql/README_UPGRADE.md
+++ b/netdisco-postgresql/README_UPGRADE.md
@@ -12,8 +12,8 @@ docker run --name pgauto -it \
   pgautoupgrade/pgautoupgrade:17-alpine
 ```
 
-Before doing so, please make sure to have a working backup. A simple way
-to create one is:
+Before doing so, please make sure to have a working backup. If you don't
+have one already, a simple way to create one is:
 
 ```
 docker-compose exec -u postgres netdisco-postgresql \
@@ -32,5 +32,15 @@ Postgres 13:
     image: netdisco/netdisco:2.080003-do
 ```
 
-We apologize for the inconvenience.
+When you are ready to use Postgres 17, set the version numbers in image:
+to `latest` again.
+
+```
+    image: netdisco/netdisco:latest-postgresql
+    etc...
+```
+
+We apologize for the inconvenience. While we can not offer full
+Postgres DBA support or any responsibility for data loss, we try to
+help with reported issues on github or the IRC channel. 
 

--- a/netdisco-postgresql/README_UPGRADE.md
+++ b/netdisco-postgresql/README_UPGRADE.md
@@ -1,0 +1,36 @@
+
+Beginning from version 2.09000 netdisco-docker includes Postgres 17, 
+while the existing database is an older major version.
+
+It's possible to upgrade the old database in-place using pgautoupgrade, 
+executed in the directory where docker-compose.yml is located:
+
+```
+docker run --name pgauto -it \
+  --mount type=bind,source=$PWD/netdisco/pgdata,target=/var/lib/postgresql/data \
+  -e PGAUTO_ONESHOT=yes \
+  pgautoupgrade/pgautoupgrade:17-alpine
+```
+
+Before doing so, please make sure to have a working backup. A simple way
+to create one is:
+
+```
+docker-compose exec -u postgres netdisco-postgresql \
+    pg_dump -c -d netdisco -C --format=p > $HOME/netdisco-backup.sql
+
+```
+
+For the above command to work, or to avoid upgrading right now, edit
+docker-compose.yml to use the last version of the images that used
+Postgres 13:
+
+```
+    image: netdisco/netdisco:2.080003-postgresql
+    image: netdisco/netdisco:2.080003-backend
+    image: netdisco/netdisco:2.080003-web
+    image: netdisco/netdisco:2.080003-do
+```
+
+We apologize for the inconvenience.
+

--- a/netdisco-postgresql/netdisco-db-entrypoint.sh
+++ b/netdisco-postgresql/netdisco-db-entrypoint.sh
@@ -10,6 +10,11 @@ if [ ! -s "${PGDATA}/PG_VERSION" ]; then
     /usr/local/bin/docker-entrypoint.sh "$@"
 fi
 
+if ! grep -q "17" "${PGDATA}/PG_VERSION" ; then
+  cat /README_UPGRADE.md
+  exit 1
+fi
+
 if [ "$1" = 'postgres' ]; then
   echo >&2 -e "${COL}netdisco-db-entrypoint: starting pg privately to container${NC}"
   "${su[@]}" pg_ctl -D "$PGDATA" -o "-c listen_addresses='localhost' -c log_min_error_statement=LOG -c log_min_messages=LOG" -w start


### PR DESCRIPTION
TL;DR: do not just merge this right now :)

I did some digging how to navigate an upgrade of the Postgres version, as 13 will be out of support next year. Unfortunately this is a bit of a support headache, since it needs manual converting of the Postgres files. I tried to include an easy one-command approach using the pgautoupgrade project: https://github.com/pgautoupgrade/docker-pgautoupgrade

How to use it is in the README_UPGRADE.md, which the PG 17 container also just dumps into the container log if there is a mismatch.

However most users probably start the container in the background, in Docker Desktop etc. and will still not immediately see it. So we should find a good time to create a new release in Netdisco proper, declare this the cutoff for netdisco-docker PG13, and then I'd hang out in the issues & IRC for a week or two, because people will probably need help :)

To try the instructions or just test Netdisco with PG17 in general, you can get the new container from my Dockerhub account - just use `rc9000/netdisco:latest-pg17` as a drop-in replacement for `netdisco:latest-postgresql`.

Actual EOL for PG13 is  November 13, 2025 so there is no rush. 