### PR TITLE
Add Helm chart for Kubernetes/OpenShift deployment

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -1,0 +1,34 @@
+name: Release Helm Chart
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'helm/**'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.6.0
+        with:
+          charts_dir: helm
+          # TODO: change to netdisco/netdisco-docker once PR is merged upstream
+          # pages_branch defaults to gh-pages
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,6 @@
 *.pid
 test.pl
 *.tar.gz
-netdisco
+/netdisco
 !netdisco-*/hooks/*
 .idea

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![CPAN version](https://badge.fury.io/pl/App-Netdisco.svg)](https://metacpan.org/pod/App::Netdisco)
 [![Docker Image](https://img.shields.io/badge/docker%20images-ready-blue.svg)](https://store.docker.com/community/images/netdisco/netdisco)
+[![Helm Chart](https://img.shields.io/badge/helm%20chart-available-blue.svg)](https://netdisco.github.io/netdisco-docker)
 
 **Netdisco** is a web-based network management tool suitable for small to very large networks. IP and MAC address data is collected into a PostgreSQL database using SNMP, CLI, or device APIs. Some of the things you can do with Netdisco:
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,79 @@ If you wish to build the images locally, use [this compose file](https://raw.git
 
     docker compose -f compose.build.yaml build --no-cache
 
+## Helm / Kubernetes Deployment
+
+A Helm chart is provided at `helm/netdisco/` for deploying Netdisco on Kubernetes or Red Hat OpenShift (RHOS).
+
+### Prerequisites
+
+- Helm 3
+- A PostgreSQL database (external recommended for production)
+- For RHOS: the Vault Agent Injector and/or External Secrets Operator if using credential injection
+
+No local Helm installation is required — all commands below use the official `alpine/helm` Docker image.
+
+### Quick start — local cluster (bundled PostgreSQL)
+
+```bash
+kind create cluster
+helm install netdisco ./helm/netdisco -f helm/netdisco/values-test.yaml
+```
+
+### OpenShift deployment (external PostgreSQL)
+
+```bash
+helm install netdisco ./helm/netdisco \
+  -f helm/netdisco/values-openshift.yaml \
+  --set db.host=mypostgres.example.com \
+  --set db.password=secret \
+  --set route.host=netdisco.apps.mycluster.example.com
+```
+
+### With Vault Agent (DB) + ESO (SNMP credentials)
+
+```bash
+helm install netdisco ./helm/netdisco \
+  -f helm/netdisco/values-openshift.yaml \
+  -f helm/netdisco/values-vault-eso.yaml \
+  --set vault.dbPath=secret/data/netdisco/db \
+  --set eso.vaultPath=secret/data/netdisco/snmp
+```
+
+Edit `values-vault-eso.yaml` to set your Vault KV paths and adjust the `deviceAuthTemplate` to match your SNMP credential structure.
+
+### Linting and dry-run (no cluster needed)
+
+```bash
+# Lint
+docker run --rm -v $(pwd)/helm/netdisco:/chart alpine/helm:latest lint /chart
+
+# Render templates
+docker run --rm -v $(pwd)/helm/netdisco:/chart alpine/helm:latest template netdisco /chart \
+  -f /chart/values-openshift.yaml --set db.password=secret
+```
+
+### Values files
+
+| File | Purpose |
+|---|---|
+| `values.yaml` | Full reference with all defaults and comments |
+| `values-test.yaml` | Local testing with bundled PostgreSQL |
+| `values-openshift.yaml` | RHOS production (external DB, Route, arbitrary UID) |
+| `values-vault-eso.yaml` | Credential injection overlay (Vault Agent + ESO) |
+
+### Credential injection architecture
+
+When `vault.enabled` or `eso.enabled` is set, an init container merges the non-sensitive ConfigMap with the injected credential files before the application starts:
+
+```
+ConfigMap (deployment.yml) ──┐
+                              ├─ init container ─► emptyDir ─► app
+Vault/ESO Secret (creds) ────┘
+```
+
+Vault Agent injects DB credentials; ESO syncs SNMP `device_auth` from Vault KV into a k8s Secret.
+
 ## Getting Support
 
 We have several other pages with tips for [understanding and troubleshooting Netdisco](https://github.com/netdisco/netdisco/wiki/Troubleshooting), [tips and tricks for specific platforms](https://github.com/netdisco/netdisco/wiki/Vendor-Tips), and [all the configuration options](https://github.com/netdisco/netdisco/wiki/Configuration).

--- a/helm/netdisco/Chart.yaml
+++ b/helm/netdisco/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: netdisco
+description: Netdisco - Open Source Network Management
+type: application
+version: 0.1.0
+appVersion: "latest"
+keywords:
+  - netdisco
+  - network
+  - snmp
+  - management
+home: https://netdisco.org
+sources:
+  - https://github.com/netdisco/netdisco-docker
+maintainers:
+  - name: The Netdisco Project
+    url: https://github.com/netdisco

--- a/helm/netdisco/templates/_helpers.tpl
+++ b/helm/netdisco/templates/_helpers.tpl
@@ -1,0 +1,91 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "netdisco.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "netdisco.fullname" -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "netdisco.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "netdisco.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- define "netdisco.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+app.kubernetes.io/name: {{ include "netdisco.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "netdisco.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "netdisco.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/* Database host: bundled postgresql service or external */}}
+{{- define "netdisco.dbHost" -}}
+{{- if .Values.postgresql.enabled -}}
+{{ include "netdisco.fullname" . }}-postgresql
+{{- else -}}
+{{ required "db.host is required when postgresql.enabled is false" .Values.db.host }}
+{{- end }}
+{{- end }}
+
+{{/* Security context — drop runAsUser on OpenShift */}}
+{{- define "netdisco.securityContext" -}}
+runAsNonRoot: true
+{{- if not .Values.openshift }}
+runAsUser: {{ .Values.securityContext.runAsUser }}
+runAsGroup: {{ .Values.securityContext.runAsGroup }}
+fsGroup: {{ .Values.securityContext.fsGroup }}
+{{- end }}
+{{- end }}
+
+{{/* Common env vars for all netdisco containers */}}
+{{- define "netdisco.env" -}}
+- name: NETDISCO_DOMAIN
+  value: {{ .Values.netdisco.domain | quote }}
+- name: NETDISCO_DB_HOST
+  value: {{ include "netdisco.dbHost" . | quote }}
+- name: NETDISCO_DB_PORT
+  value: {{ .Values.db.port | quote }}
+- name: NETDISCO_DB_NAME
+  value: {{ .Values.db.name | quote }}
+- name: NETDISCO_DB_USER
+  value: {{ .Values.db.user | quote }}
+- name: NETDISCO_DB_PASS
+  valueFrom:
+    secretKeyRef:
+      name: {{ if .Values.db.existingSecret }}{{ .Values.db.existingSecret }}{{ else }}{{ include "netdisco.fullname" . }}-db{{ end }}
+      key: db-password
+{{- end }}
+
+{{/* Common volume mounts */}}
+{{- define "netdisco.volumeMounts" -}}
+- name: config
+  mountPath: /home/netdisco/environments
+  readOnly: true
+{{- if .Values.persistence.enabled }}
+- name: nd-site-local
+  mountPath: /home/netdisco/nd-site-local
+{{- end }}
+{{- end }}
+
+{{/* Common volumes */}}
+{{- define "netdisco.volumes" -}}
+- name: config
+  configMap:
+    name: {{ include "netdisco.fullname" . }}-config
+{{- if .Values.persistence.enabled }}
+- name: nd-site-local
+  persistentVolumeClaim:
+    claimName: {{ include "netdisco.fullname" . }}-nd-site-local
+{{- end }}
+{{- end }}

--- a/helm/netdisco/templates/_helpers.tpl
+++ b/helm/netdisco/templates/_helpers.tpl
@@ -48,7 +48,12 @@ fsGroup: {{ .Values.securityContext.fsGroup }}
 {{- end }}
 {{- end }}
 
-{{/* Common env vars for all netdisco containers */}}
+{{/* True when any credential injection is active */}}
+{{- define "netdisco.credentialsEnabled" -}}
+{{- or .Values.vault.enabled .Values.eso.enabled }}
+{{- end }}
+
+{{/* Common env vars — DB password from Secret unless Vault injects it */}}
 {{- define "netdisco.env" -}}
 - name: NETDISCO_DOMAIN
   value: {{ .Values.netdisco.domain | quote }}
@@ -60,29 +65,90 @@ fsGroup: {{ .Values.securityContext.fsGroup }}
   value: {{ .Values.db.name | quote }}
 - name: NETDISCO_DB_USER
   value: {{ .Values.db.user | quote }}
+{{- if not .Values.vault.enabled }}
 - name: NETDISCO_DB_PASS
   valueFrom:
     secretKeyRef:
       name: {{ if .Values.db.existingSecret }}{{ .Values.db.existingSecret }}{{ else }}{{ include "netdisco.fullname" . }}-db{{ end }}
       key: db-password
 {{- end }}
+{{- end }}
 
-{{/* Common volume mounts */}}
+{{/* Vault Agent Injector pod annotations */}}
+{{- define "netdisco.vaultAnnotations" -}}
+{{- if .Values.vault.enabled }}
+vault.hashicorp.com/agent-inject: "true"
+vault.hashicorp.com/role: {{ .Values.vault.role | quote }}
+vault.hashicorp.com/agent-inject-secret-db-credentials: {{ .Values.vault.dbPath | quote }}
+vault.hashicorp.com/agent-inject-template-db-credentials: |
+  {{`{{- with secret `}}"{{ .Values.vault.dbPath }}"{{` -}}`}}
+  database:
+    pass: '{{`{{ .Data.data.`}}{{ .Values.vault.dbPasswordKey }}{{` }}`}}'
+  {{`{{- end }}`}}
+{{- end }}
+{{- end }}
+
+{{/* Init container that merges ConfigMap + injected credential files */}}
+{{- define "netdisco.initContainer" -}}
+{{- if include "netdisco.credentialsEnabled" . }}
+- name: merge-config
+  image: alpine:3
+  command:
+    - sh
+    - -c
+    - |
+      cp /config-src/deployment.yml /merged/deployment.yml
+      {{- if .Values.vault.enabled }}
+      cat /vault/secrets/db-credentials >> /merged/deployment.yml
+      {{- end }}
+      {{- if .Values.eso.enabled }}
+      cat /credentials/device_auth.yml >> /merged/deployment.yml
+      {{- end }}
+  volumeMounts:
+    - name: config-src
+      mountPath: /config-src
+      readOnly: true
+    - name: config
+      mountPath: /merged
+    {{- if .Values.eso.enabled }}
+    - name: credentials
+      mountPath: /credentials
+      readOnly: true
+    {{- end }}
+{{- end }}
+{{- end }}
+
+{{/* Volume mounts for app containers */}}
 {{- define "netdisco.volumeMounts" -}}
 - name: config
   mountPath: /home/netdisco/environments
+  {{- if not (include "netdisco.credentialsEnabled" .) }}
   readOnly: true
+  {{- end }}
 {{- if .Values.persistence.enabled }}
 - name: nd-site-local
   mountPath: /home/netdisco/nd-site-local
 {{- end }}
 {{- end }}
 
-{{/* Common volumes */}}
+{{/* Volumes */}}
 {{- define "netdisco.volumes" -}}
+{{- if include "netdisco.credentialsEnabled" . }}
+- name: config-src
+  configMap:
+    name: {{ include "netdisco.fullname" . }}-config
+- name: config
+  emptyDir: {}
+{{- else }}
 - name: config
   configMap:
     name: {{ include "netdisco.fullname" . }}-config
+{{- end }}
+{{- if .Values.eso.enabled }}
+- name: credentials
+  secret:
+    secretName: {{ include "netdisco.fullname" . }}-credentials
+{{- end }}
 {{- if .Values.persistence.enabled }}
 - name: nd-site-local
   persistentVolumeClaim:

--- a/helm/netdisco/templates/configmap.yaml
+++ b/helm/netdisco/templates/configmap.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "netdisco.fullname" . }}-config
+  labels:
+    {{- include "netdisco.labels" . | nindent 4 }}
+data:
+  deployment.yml: |
+    database:
+      name: '{{ .Values.db.name }}'
+      user: '{{ .Values.db.user }}'
+      host: '{{ include "netdisco.dbHost" . }}'
+      port: {{ .Values.db.port }}
+
+    domain_suffix: ['']
+    {{- if .Values.netdisco.extraConfig }}
+    {{ .Values.netdisco.extraConfig | nindent 4 }}
+    {{- end }}

--- a/helm/netdisco/templates/deployment-backend.yaml
+++ b/helm/netdisco/templates/deployment-backend.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "netdisco.fullname" . }}-backend
+  labels:
+    {{- include "netdisco.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  replicas: {{ .Values.backend.replicas }}
+  selector:
+    matchLabels:
+      {{- include "netdisco.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: backend
+  template:
+    metadata:
+      labels:
+        {{- include "netdisco.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: backend
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+    spec:
+      serviceAccountName: {{ include "netdisco.serviceAccountName" . }}
+      securityContext:
+        {{- include "netdisco.securityContext" . | nindent 8 }}
+      containers:
+        - name: backend
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}-backend"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            {{- include "netdisco.env" . | nindent 12 }}
+          volumeMounts:
+            {{- include "netdisco.volumeMounts" . | nindent 12 }}
+          {{- with .Values.backend.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        {{- include "netdisco.volumes" . | nindent 8 }}

--- a/helm/netdisco/templates/deployment-backend.yaml
+++ b/helm/netdisco/templates/deployment-backend.yaml
@@ -18,10 +18,15 @@ spec:
         app.kubernetes.io/component: backend
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- include "netdisco.vaultAnnotations" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "netdisco.serviceAccountName" . }}
       securityContext:
         {{- include "netdisco.securityContext" . | nindent 8 }}
+      {{- if include "netdisco.credentialsEnabled" . }}
+      initContainers:
+        {{- include "netdisco.initContainer" . | nindent 8 }}
+      {{- end }}
       containers:
         - name: backend
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}-backend"

--- a/helm/netdisco/templates/deployment-web.yaml
+++ b/helm/netdisco/templates/deployment-web.yaml
@@ -18,10 +18,15 @@ spec:
         app.kubernetes.io/component: web
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- include "netdisco.vaultAnnotations" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "netdisco.serviceAccountName" . }}
       securityContext:
         {{- include "netdisco.securityContext" . | nindent 8 }}
+      {{- if include "netdisco.credentialsEnabled" . }}
+      initContainers:
+        {{- include "netdisco.initContainer" . | nindent 8 }}
+      {{- end }}
       containers:
         - name: web
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}-web"

--- a/helm/netdisco/templates/deployment-web.yaml
+++ b/helm/netdisco/templates/deployment-web.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "netdisco.fullname" . }}-web
+  labels:
+    {{- include "netdisco.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+spec:
+  replicas: {{ .Values.web.replicas }}
+  selector:
+    matchLabels:
+      {{- include "netdisco.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: web
+  template:
+    metadata:
+      labels:
+        {{- include "netdisco.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: web
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+    spec:
+      serviceAccountName: {{ include "netdisco.serviceAccountName" . }}
+      securityContext:
+        {{- include "netdisco.securityContext" . | nindent 8 }}
+      containers:
+        - name: web
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}-web"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.web.port }}
+              protocol: TCP
+          env:
+            {{- include "netdisco.env" . | nindent 12 }}
+            - name: PORT
+              value: {{ .Values.web.port | quote }}
+          volumeMounts:
+            {{- include "netdisco.volumeMounts" . | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          {{- with .Values.web.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        {{- include "netdisco.volumes" . | nindent 8 }}

--- a/helm/netdisco/templates/external-secret.yaml
+++ b/helm/netdisco/templates/external-secret.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.eso.enabled }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "netdisco.fullname" . }}-credentials
+  labels:
+    {{- include "netdisco.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.eso.refreshInterval }}
+  secretStoreRef:
+    kind: {{ .Values.eso.secretStoreKind }}
+    name: {{ .Values.eso.secretStoreName }}
+  target:
+    name: {{ include "netdisco.fullname" . }}-credentials
+    template:
+      data:
+        device_auth.yml: |
+          {{- .Values.eso.deviceAuthTemplate | nindent 10 }}
+  dataFrom:
+    - extract:
+        key: {{ .Values.eso.vaultPath }}
+{{- end }}

--- a/helm/netdisco/templates/ingress.yaml
+++ b/helm/netdisco/templates/ingress.yaml
@@ -1,0 +1,31 @@
+{{- if and .Values.ingress.enabled (not .Values.openshift) }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "netdisco.fullname" . }}
+  labels:
+    {{- include "netdisco.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "netdisco.fullname" . }}-web
+                port:
+                  name: http
+{{- end }}

--- a/helm/netdisco/templates/job-db-init.yaml
+++ b/helm/netdisco/templates/job-db-init.yaml
@@ -21,6 +21,10 @@ spec:
       serviceAccountName: {{ include "netdisco.serviceAccountName" . }}
       securityContext:
         {{- include "netdisco.securityContext" . | nindent 8 }}
+      {{- if include "netdisco.credentialsEnabled" . }}
+      initContainers:
+        {{- include "netdisco.initContainer" . | nindent 8 }}
+      {{- end }}
       containers:
         - name: db-init
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}-backend"

--- a/helm/netdisco/templates/job-db-init.yaml
+++ b/helm/netdisco/templates/job-db-init.yaml
@@ -1,0 +1,36 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "netdisco.fullname" . }}-db-init
+  labels:
+    {{- include "netdisco.labels" . | nindent 4 }}
+  annotations:
+    # Run on every helm upgrade too
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  backoffLimit: 5
+  template:
+    metadata:
+      labels:
+        {{- include "netdisco.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: db-init
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: {{ include "netdisco.serviceAccountName" . }}
+      securityContext:
+        {{- include "netdisco.securityContext" . | nindent 8 }}
+      containers:
+        - name: db-init
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}-backend"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /home/netdisco/bin/netdisco-env
+            - /home/netdisco/bin/netdisco-updatedb.sh
+          env:
+            {{- include "netdisco.env" . | nindent 12 }}
+          volumeMounts:
+            {{- include "netdisco.volumeMounts" . | nindent 12 }}
+      volumes:
+        {{- include "netdisco.volumes" . | nindent 8 }}

--- a/helm/netdisco/templates/postgresql.yaml
+++ b/helm/netdisco/templates/postgresql.yaml
@@ -1,0 +1,88 @@
+{{- if .Values.postgresql.enabled }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "netdisco.fullname" . }}-postgresql
+  labels:
+    {{- include "netdisco.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  postgres-password: {{ .Values.postgresql.password | quote }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "netdisco.fullname" . }}-postgresql
+  labels:
+    {{- include "netdisco.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgresql
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5432
+      targetPort: postgresql
+      name: postgresql
+  selector:
+    {{- include "netdisco.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: postgresql
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "netdisco.fullname" . }}-postgresql
+  labels:
+    {{- include "netdisco.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgresql
+spec:
+  serviceName: {{ include "netdisco.fullname" . }}-postgresql
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "netdisco.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: postgresql
+  template:
+    metadata:
+      labels:
+        {{- include "netdisco.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: postgresql
+    spec:
+      containers:
+        - name: postgresql
+          image: {{ .Values.postgresql.image }}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: postgresql
+              containerPort: 5432
+          env:
+            - name: POSTGRES_DB
+              value: {{ .Values.db.name | quote }}
+            - name: POSTGRES_USER
+              value: {{ .Values.db.user | quote }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "netdisco.fullname" . }}-postgresql
+                  key: postgres-password
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", {{ .Values.db.user | quote }}]
+            initialDelaySeconds: 10
+            periodSeconds: 5
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: {{ .Values.postgresql.storage }}
+        {{- if .Values.postgresql.storageClass }}
+        storageClassName: {{ .Values.postgresql.storageClass }}
+        {{- end }}
+{{- end }}

--- a/helm/netdisco/templates/pvc.yaml
+++ b/helm/netdisco/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "netdisco.fullname" . }}-nd-site-local
+  labels:
+    {{- include "netdisco.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
+{{- end }}

--- a/helm/netdisco/templates/route.yaml
+++ b/helm/netdisco/templates/route.yaml
@@ -1,0 +1,22 @@
+{{- if or .Values.route.enabled .Values.openshift }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "netdisco.fullname" . }}
+  labels:
+    {{- include "netdisco.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.route.host }}
+  host: {{ .Values.route.host }}
+  {{- end }}
+  to:
+    kind: Service
+    name: {{ include "netdisco.fullname" . }}-web
+  port:
+    targetPort: http
+  {{- if .Values.route.tls.enabled }}
+  tls:
+    termination: {{ .Values.route.tls.termination }}
+    insecureEdgeTerminationPolicy: Redirect
+  {{- end }}
+{{- end }}

--- a/helm/netdisco/templates/secret.yaml
+++ b/helm/netdisco/templates/secret.yaml
@@ -1,0 +1,11 @@
+{{- if not .Values.db.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "netdisco.fullname" . }}-db
+  labels:
+    {{- include "netdisco.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  db-password: {{ .Values.db.password | quote }}
+{{- end }}

--- a/helm/netdisco/templates/service.yaml
+++ b/helm/netdisco/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "netdisco.fullname" . }}-web
+  labels:
+    {{- include "netdisco.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "netdisco.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: web

--- a/helm/netdisco/templates/serviceaccount.yaml
+++ b/helm/netdisco/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "netdisco.serviceAccountName" . }}
+  labels:
+    {{- include "netdisco.labels" . | nindent 4 }}
+{{- end }}

--- a/helm/netdisco/values-openshift.yaml
+++ b/helm/netdisco/values-openshift.yaml
@@ -1,0 +1,64 @@
+# values-openshift.yaml — Red Hat OpenShift deployment
+# Usage: helm install netdisco ./helm/netdisco -f helm/netdisco/values-openshift.yaml -f my-secrets.yaml
+
+openshift: true
+
+# RHOS assigns an arbitrary UID — do not fix runAsUser
+securityContext:
+  runAsNonRoot: true
+
+route:
+  enabled: true
+  host: netdisco.apps.mycluster.example.com   # adjust to your cluster domain
+  tls:
+    enabled: true
+    termination: edge
+
+ingress:
+  enabled: false
+
+# External DB — fill in or use an existingSecret
+db:
+  host: mypostgres.example.com
+  port: 5432
+  name: netdisco
+  user: netdisco
+  password: ""          # set via --set db.password=... or existingSecret
+  existingSecret: ""    # e.g. name of a Secret with key db-password
+
+postgresql:
+  enabled: false
+
+# Shared storage — RHOS typically needs RWX (e.g. CephFS, NFS)
+persistence:
+  enabled: true
+  size: 1Gi
+  accessMode: ReadWriteMany
+  storageClass: ""      # set to your RWX storageclass, e.g. ocs-storagecluster-cephfs
+
+web:
+  replicas: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
+
+backend:
+  replicas: 1
+  resources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
+
+netdisco:
+  domain: discover
+  extraConfig: |
+    #metrics_path: '/metrics'
+    #device_auth:
+    #  - tag: default_v2_readonly
+    #    community: public
+    #    read: true

--- a/helm/netdisco/values-test.yaml
+++ b/helm/netdisco/values-test.yaml
@@ -1,0 +1,47 @@
+# values-test.yaml — minimal local/CI test with bundled PostgreSQL
+# Usage: helm install netdisco ./helm/netdisco -f helm/netdisco/values-test.yaml
+#
+# Requires a k8s/k3s/kind cluster. For a quick local cluster:
+#   kind create cluster
+#   helm install netdisco ./helm/netdisco -f helm/netdisco/values-test.yaml
+
+postgresql:
+  enabled: true
+  password: testpassword
+  storage: 1Gi
+
+db:
+  host: ""      # ignored when postgresql.enabled=true
+  name: netdisco
+  user: netdisco
+  password: testpassword
+
+persistence:
+  enabled: true
+  size: 100Mi
+  accessMode: ReadWriteOnce
+
+ingress:
+  enabled: false
+
+route:
+  enabled: false
+
+# Expose web via NodePort for easy local access
+service:
+  type: NodePort
+
+web:
+  replicas: 1
+
+backend:
+  replicas: 1
+
+netdisco:
+  domain: discover
+  extraConfig: |
+    no_auth: true
+    device_auth:
+      - tag: default_v2_readonly
+        community: public
+        read: true

--- a/helm/netdisco/values-vault-eso.yaml
+++ b/helm/netdisco/values-vault-eso.yaml
@@ -1,0 +1,46 @@
+# values-vault-eso.yaml — Vault Agent (DB) + ESO (SNMP credentials)
+# Usage:
+#   helm install netdisco ./helm/netdisco \
+#     -f helm/netdisco/values-openshift.yaml \
+#     -f helm/netdisco/values-vault-eso.yaml
+
+# -- Vault Agent Injector: DB password
+# The Vault Agent sidecar injects DB credentials as a YAML file that is
+# merged into deployment.yml by the init container.
+# Vault secret must contain a key matching vault.dbPasswordKey.
+vault:
+  enabled: true
+  role: netdisco
+  dbPath: "secret/data/netdisco/db"      # KV v2 path
+  dbPasswordKey: "password"              # key within the secret
+
+# -- ESO: SNMP device_auth credentials
+# ESO fetches all keys from vaultPath and renders them into device_auth.yml
+# via the deviceAuthTemplate. Adjust the template to match your Vault structure.
+eso:
+  enabled: true
+  secretStoreKind: ClusterSecretStore
+  secretStoreName: vault-backend
+  refreshInterval: 1h
+  vaultPath: "secret/data/netdisco/snmp"
+
+  # Render Netdisco device_auth from Vault keys.
+  # Keys are referenced with {{ .key_name }} — these must exist in vaultPath.
+  # Add one entry per SNMP community/v3 profile you have in Vault.
+  deviceAuthTemplate: |
+    device_auth:
+      # SNMPv2 read-only (community string from Vault key 'snmp_ro_community')
+      - tag: default_v2_readonly
+        community: '{{ .snmp_ro_community }}'
+        read: true
+        write: false
+
+      # SNMPv3 authPriv example (keys: snmp_v3_user, snmp_v3_auth, snmp_v3_priv)
+      # - tag: default_v3
+      #   username: '{{ .snmp_v3_user }}'
+      #   auth_password: '{{ .snmp_v3_auth }}'
+      #   priv_password: '{{ .snmp_v3_priv }}'
+      #   auth_protocol: SHA
+      #   priv_protocol: AES
+      #   version: 3
+      #   read: true

--- a/helm/netdisco/values.yaml
+++ b/helm/netdisco/values.yaml
@@ -1,0 +1,93 @@
+image:
+  repository: netdisco/netdisco
+  tag: latest
+  pullPolicy: IfNotPresent
+
+# -- External PostgreSQL (primary/default)
+db:
+  host: ""
+  port: 5432
+  name: netdisco
+  user: netdisco
+  password: ""
+  # name of an existing Secret with keys: db-password
+  existingSecret: ""
+
+# -- Bundled PostgreSQL for minimal testing only (not for production)
+postgresql:
+  enabled: false
+  image: postgres:16-alpine
+  password: netdisco
+  storage: 5Gi
+  storageClass: ""
+
+# -- Netdisco application config (mounted as deployment.yml)
+netdisco:
+  domain: discover
+  # Additional raw config appended to deployment.yml.
+  # Use this for device_auth, schedule overrides, metrics settings, etc.
+  extraConfig: |
+    #device_auth:
+    #  - tag: default_v2_readonly
+    #    community: public
+    #    read: true
+
+web:
+  replicas: 1
+  port: 5000
+  resources: {}
+  #  requests:
+  #    cpu: 100m
+  #    memory: 256Mi
+  #  limits:
+  #    memory: 512Mi
+
+backend:
+  replicas: 1
+  resources: {}
+
+# -- OpenShift Route (use this on RHOS)
+route:
+  enabled: false
+  host: ""
+  tls:
+    enabled: true
+    termination: edge
+
+# -- Kubernetes Ingress (use this on plain k8s)
+ingress:
+  enabled: false
+  className: ""
+  host: ""
+  tls: []
+  annotations: {}
+
+service:
+  type: ClusterIP
+  port: 80
+
+# -- Persistent storage for nd-site-local (custom MIBs, plugins, etc.)
+persistence:
+  enabled: true
+  size: 1Gi
+  storageClass: ""
+  accessMode: ReadWriteMany
+
+# -- Security context
+# RHOS: set runAsUser to null to let OpenShift assign arbitrary UID
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 901
+  runAsGroup: 901
+  fsGroup: 901
+
+# openshift: true will set runAsUser: null and add Route instead of Ingress
+openshift: false
+
+serviceAccount:
+  create: true
+  name: ""
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/helm/netdisco/values.yaml
+++ b/helm/netdisco/values.yaml
@@ -91,3 +91,46 @@ serviceAccount:
 nodeSelector: {}
 tolerations: []
 affinity: {}
+
+# -- Vault Agent Injector for DB credentials
+# Requires the Vault Agent Injector to be installed in the cluster.
+# When enabled, DB password is read from the Vault-injected file instead
+# of the k8s Secret. The injected file must render a YAML snippet:
+#   database:
+#     pass: 'the-password'
+vault:
+  enabled: false
+  role: netdisco
+  # KV v2 path to the secret containing the DB password
+  dbPath: "secret/data/netdisco/db"
+  # Key within the secret that holds the password
+  dbPasswordKey: "password"
+
+# -- External Secrets Operator for SNMP device_auth credentials
+# Requires ESO to be installed and a SecretStore/ClusterSecretStore configured.
+# ESO syncs Vault KV -> k8s Secret. The Secret must contain a key
+# 'device_auth.yml' with a valid Netdisco device_auth YAML block.
+# Use the deviceAuthTemplate to render credentials from Vault keys.
+eso:
+  enabled: false
+  secretStoreKind: ClusterSecretStore   # or SecretStore
+  secretStoreName: vault-backend
+  refreshInterval: 1h
+  # Vault KV v2 path containing SNMP credential keys
+  vaultPath: "secret/data/netdisco/snmp"
+  # Template rendered into device_auth.yml inside the k8s Secret.
+  # Reference Vault keys with {{ .keyname }} notation.
+  # See: https://external-secrets.io/latest/guides/templating/
+  deviceAuthTemplate: |
+    device_auth:
+      - tag: default_v2_readonly
+        community: '{{ .snmp_community_ro }}'
+        read: true
+        write: false
+      # SNMPv3 example:
+      # - tag: core_v3
+      #   auth_password: '{{ .core_v3_password }}'
+      #   priv_password: '{{ .core_v3_key }}'
+      #   auth_protocol: SHA
+      #   priv_protocol: AES
+      #   version: 3


### PR DESCRIPTION
- Helm chart at `helm/netdisco/` for Kubernetes and OpenShift deployment
- External PostgreSQL by default; optional bundled PostgreSQL for testing
- Vault Agent Injector support for DB password injection
- External Secrets Operator (ESO) support for SNMP `device_auth` credentials
- Init container merges ConfigMap + injected credential files into final `deployment.yml`
- Fixed `.gitignore` — anchored `/netdisco` so `helm/netdisco/` is no longer ignored
- Update `README.md`

**Three value overlays included:**

| File | Use case |
|---|---|
| `values-test.yaml` | Local kind/k3s with bundled PostgreSQL |
| `values-openshift.yaml` | RHOS with external DB and Route |
| `values-vault-eso.yaml` | Vault Agent (DB) + ESO (SNMP) overlay on top of openshift values |

## Tests render samples

```bash
# Lint
docker run --rm -v $(pwd)/helm/netdisco:/chart alpine/helm:latest lint /chart

# Dry-run: bundled PostgreSQL
docker run --rm -v $(pwd)/helm/netdisco:/chart alpine/helm:latest template netdisco /chart \
  -f /chart/values-test.yaml

# Dry-run: OpenShift + external DB
docker run --rm -v $(pwd)/helm/netdisco:/chart alpine/helm:latest template netdisco /chart \
  -f /chart/values-openshift.yaml --set db.password=secret

# Dry-run: Vault + ESO overlay
docker run --rm -v $(pwd)/helm/netdisco:/chart alpine/helm:latest template netdisco /chart \
  -f /chart/values-openshift.yaml -f /chart/values-vault-eso.yaml

# Deploy to local kind cluster
kind create cluster
helm install netdisco ./helm/netdisco -f helm/netdisco/values-test.yaml
```

## Notes

- Vault path and ESO `deviceAuthTemplate` in `values-vault-eso.yaml` are samples — adjust to match your Vault KV structure
- RHOS arbitrary UID: set `openshift: true` to drop `runAsUser` and enable Route instead of Ingress
- Vault/ESO wiring is opt-in (`vault.enabled`, `eso.enabled`) — plain k8s deployments are unaffected