### PR TITLE
cleanup: drop log and smoketest pimp

### DIFF
--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Prepare host directories
         run: |
-          mkdir -p netdisco/logs netdisco/config netdisco/nd-site-local
+          mkdir -p netdisco/config netdisco/nd-site-local
           sudo chown -R 901:901 netdisco
 
       - name: Start the stack
@@ -72,6 +72,28 @@ jobs:
               exit 1
             fi
           done
+
+      - name: Confirm no real log files written (foreground mode)
+        run: |
+          # Post netdisco/netdisco#1500: foreground mode skips log file
+          # creation entirely. The Dockerfile keeps the legacy
+          # /home/netdisco/logs/netdisco-*.log -> /dev/stdout symlinks as a
+          # safety net for non-foreground use, so '-type f' excludes those
+          # and only catches *real* files (which would mean log writes
+          # accumulating inside the container instead of reaching stdout).
+          fail=0
+          for svc in netdisco-backend netdisco-web; do
+            real=$(docker compose exec -T "$svc" find /home/netdisco/logs \
+              -maxdepth 1 -type f -name '*.log' 2>/dev/null || true)
+            if [ -n "$real" ]; then
+              echo "FAIL: $svc has real log files (expected stdout only):"
+              echo "$real"
+              fail=1
+            else
+              echo "OK: $svc — no real .log files in /home/netdisco/logs/"
+            fi
+          done
+          exit $fail
 
       - name: Dump compose logs
         if: always()

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ On Linux hosts, create these directories and allow the service uid (`901`) to wr
 
 *(this step is only necessary on Linux hosts and can be omitted in the macOS and Windows versions of Docker)*
 
-    mkdir -p netdisco/{logs,config,nd-site-local} 
+    mkdir -p netdisco/{config,nd-site-local}
     sudo chown -R 901:901 netdisco
 
 ###  New Deployments
@@ -35,7 +35,7 @@ Download `compose.yaml` and start everything:
 
 This runs the database, backend daemon, and web frontend listening on port 5000. If you have a device using the SNMP community `public`, enter it in the Netdisco homepage and click "Discover".
 
-The default configuration is available in `netdisco/config/deployment.yml`. The daemons automatically restart when you save changes to this file. Logs are available in `netdisco/logs/`.
+The default configuration is available in `netdisco/config/deployment.yml`. The daemons automatically restart when you save changes to this file. Logs are available via `docker compose logs` (the daemons write directly to the container stdout in foreground mode).
 
 The web frontend is initally configured to allow unauthenticated access with full admin rights. We suggest you visit the `Admin -> User Management` menu item, and set `no_auth: false` in `deployment.yml`, to remove this guest account and set up authenticated user access.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,6 @@ services:
     volumes:
       - "./netdisco/nd-site-local:/home/netdisco/nd-site-local"
       - "./netdisco/config:/home/netdisco/environments"
-      - "./netdisco/logs:/home/netdisco/logs"
     environment:
       <<: *common-environment
     dns_opt:
@@ -93,7 +92,6 @@ services:
     volumes:
       - "./netdisco/nd-site-local:/home/netdisco/nd-site-local"
       - "./netdisco/config:/home/netdisco/environments"
-      - "./netdisco/logs:/home/netdisco/logs"
     environment:
       <<: *common-environment
       IPV: '${IPV:-4}'


### PR DESCRIPTION
Now that [netdisco/netdisco#1500](https://github.com/netdisco/netdisco/pull/1500) (skip log file redirection in foreground mode) is in netdisco master:

- **`docker-compose.yml`**: drop the `./netdisco/logs:/home/netdisco/logs` bind mount on both `netdisco-backend` and `netdisco-web`. The mount served only to materialise the `netdisco-*.log -> /dev/stdout` symlink target on the host
- **README**:  adjust log refreences
- **`.github/workflows/smoke-test.yaml`**: add an assertion that /home/netdisco/logs has no logs. 

The two `ln -s /dev/stdout /home/netdisco/logs/netdisco-*.log` symlinks in `netdisco-base/Dockerfile` are retained. They cost nothing in foreground mode (unused), and they preserve correct behaviour for anyone who overrides CMD to run the daemons in non-foreground / `start` mode. Their presence also lets this PR merge **independently of the netdisco release schedule**: published images that are still on netdisco 2.098002 (pre-#1500) will continue to work because the symlinks still route their log writes to container stdout.

Suggest holding this open until at least one published netdisco-docker image build from a netdisco release #1500 has shipped, so users who pull `:latest` after the merge see the new behaviour end-to-end. The image keeps working in the meantime regardless.

## Test plan
- [ ] Smoke test workflow runs green on this PR (default args = current netdisco master, post-#1500)
- [ ] Manually trigger `workflow_dispatch` against `netdisco_git_url=https://github.com/netdisco/netdisco.git`, `committish=2.098002` (pre-#1500) and verify the new "no real log files" assertion correctly fails — proving the regression catcher works
- [ ] After merge, confirm \`docker compose up` no longer requires `mkdir netdisco/logs` and `docker compose logs` still shows daemon output