### PR TITLE
image: make it OpenShift friendly for arbitrary UID

### DIFF
--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -39,6 +39,22 @@ jobs:
             --build-arg "COMMITTISH=${COMMITTISH}" \
             netdisco-postgresql netdisco-base netdisco-backend netdisco-web
 
+      - name: Verify image is OpenShift / arbitrary-UID compatible
+        run: |
+          set -e
+          # Run perl through the localenv wrapper as a UID outside the image's
+          # netdisco user range — same failure mode as OpenShift restricted-v2
+          # SCC. local::lib must be able to bootstrap (i.e. /home/netdisco
+          # has to be writable for supplemental gid 0).
+          for tag in latest-base latest-backend latest-web; do
+            echo "::group::arbitrary UID test: netdisco/netdisco:$tag"
+            docker run --rm --user 1000050000 \
+              --entrypoint /home/netdisco/bin/localenv \
+              "netdisco/netdisco:$tag" \
+              perl -e 'print "ok\n"'
+            echo "::endgroup::"
+          done
+
       - name: Prepare host directories
         run: |
           mkdir -p netdisco/logs netdisco/config netdisco/nd-site-local

--- a/netdisco-base/Dockerfile
+++ b/netdisco-base/Dockerfile
@@ -132,6 +132,12 @@ LABEL org.label-schema.docker.schema-version="1.0" \
 # clone docker.io/postgres:18-alpine3.22 but without Dockerfile config
 COPY --from=netdisco-base-image / /
 
+# Make /home/netdisco writable under arbitrary UIDs (OpenShift random UID,
+# kubectl runAsUser, etc.) by routing access via supplemental gid 0, which
+# is added to every container by OpenShift. Harmless when the image runs
+# as the netdisco user (the default in docker compose).
+RUN chgrp -R 0 /home/netdisco && chmod -R g=u /home/netdisco
+
 USER netdisco:netdisco
 WORKDIR /home/netdisco
 ENV PATH="/home/netdisco/bin:$PATH"


### PR DESCRIPTION
Closes #113.

The base image creates `/home/netdisco` as `netdisco:netdisco` mode 0755. Under any container runtime that assigns an arbitrary UID, the process can read and traverse `/home/netdisco/` but cannot write to it. `local::lib` then fails before the daemon even starts when it tries to create a per-perl-version directory under `perl5/lib/perl5/`.
this should be simply fixed by 

```dockerfile
RUN chgrp -R 0 /home/netdisco && chmod -R g=u /home/netdisco
```

This is the standard ["OpenShift-compatible image" pattern](https://docs.openshift.com/container-platform/latest/openshift_images/create-images.html#use-uid_create-images). 


ToDo:
- [x] Smoke test workflow runs green (existing assertions + new arbitrary-UID assertion)
- [x] Manually re-run the reproduction from #113 
- [x] Confirm `docker compose up` still works :)
- [x] simplify helm chart https://github.com/netdisco/helm-charts/pull/1